### PR TITLE
Add additional optional parameters for styling the busy component

### DIFF
--- a/Pixata.Blazor/Containers/Busy.razor
+++ b/Pixata.Blazor/Containers/Busy.razor
@@ -1,18 +1,42 @@
 ﻿@if (Data == null) {
-  <p><span class="fad fa-spin fa-spinner" aria-hidden="true"></span> @Message</p>
+	<div class="@ContainerClass">
+		<p><span class="@SpinnerClass" aria-hidden="true" style="color: @SpinnerColour;"></span> @Message</p>
+	</div>
 } else {
-  @ChildContent
+	@ChildContent
 }
 
 @code {
+	/// <summary>
+	/// Message to show whilst loading
+	/// </summary>
+	[Parameter]
+	public string Message { get; set; } = "Loading...";
 
-  [Parameter]
-  public string Message { get; set; } = "Loading...";
+	/// <summary>
+	/// The data on which to await the loading
+	/// </summary>
+	[Parameter]
+	public object Data { get; set; }
 
-  [Parameter]
-  public object Data { get; set; }
+	[Parameter]
+	public RenderFragment ChildContent { get; set; }
 
-  [Parameter]
-  public RenderFragment ChildContent { get; set; }
+	/// <summary>
+	/// This helps with styling the busy indicator. You may wish to center it using the 'text-center' Bootstrap class
+	/// </summary>
+	[Parameter]
+	public string ContainerClass { get; set; }
 
+	/// <summary>
+	/// Change the default Bootstrap spinner to something else, e.g. a Font Awesome class
+	/// </summary>
+	[Parameter]
+	public string SpinnerClass { get; set; } = "spinner-border spinner-border-sm";
+
+	/// <summary>
+	/// Optionally add a colour to match the rest of the page
+	/// </summary>
+	[Parameter]
+	public string SpinnerColour { get; set; } = "inherit";
 }


### PR DESCRIPTION
I have edited the Busy indicator to include additional optional parameters to add an overall class, as well as the colour for the spinner. The default spinner class is set to the Bootstrap one. This can be overridden to use Font Awesome if it is included in your project.